### PR TITLE
Bug #1142: Reload apache after installation

### DIFF
--- a/debian/bluecherry.postinst
+++ b/debian/bluecherry.postinst
@@ -33,7 +33,12 @@ case "$1" in
 		a2enmod php5
 		a2ensite bluecherry
 
-#		reload rsyslog
+		if [ ! -z `which service` ]; then
+			service apache2 reload
+			service rsyslog reload
+		else
+			/etc/init.d/apache2 reload
+		fi
 
 		if [ ! -e /var/lib/.bcins ]; then
 			date +'%s' > /var/lib/.bcins


### PR DESCRIPTION
This was accidentally introduced when adding non-upstart debian support; I
can't verify that at the moment, but theoretically this fix should be okay.
