### PR TITLE
Nightly build support

### DIFF
--- a/buildreleases
+++ b/buildreleases
@@ -30,11 +30,12 @@ endif
 
 # log-paths is used to filter-out uninteresting changes
 log-paths = lib server www misc/sql
+log-date = $(shell date -R)
 
 debian/changelog: FORCE
 	echo -e 'bluecherry 1:$(VERSION)-nightly1 $(DIST); urgency=low\n' > $@
 	git log --pretty=format:'  * %s' ^$(version-tag) HEAD -- $(log-paths) >> $@
-	echo -e '\n\n -- $(MAINTAINER)\n' >> $@
+	echo -e '\n\n -- $(MAINTAINER)  $(log-date)\n' >> $@
 	git show 'HEAD:$@' >> $@
 
 #


### PR DESCRIPTION
It requires to use annotated tags to detect versions.

I've not made it to use normal tags because we might want to use lightweight tags for other purposes, while annotated tags are always significant (i.e. meant to be milestones), I guess.
