### PR TITLE
buildreleases: Fix version extraction and handling

### DIFF
--- a/buildreleases
+++ b/buildreleases
@@ -13,7 +13,17 @@ O = ../releases
 #
 # Magic suff from here
 #
-VERSION := $(shell git describe | sed 's/^v//;s/-g[0-9a-f]*$$//')
+ifeq ($(MAKECMDGOALS),nightly)
+ver-tmp := $(shell git describe | sed 's/^v//;s/-g[0-9a-f]*$$//;s/-/ /')
+ver-tag := $(word 1,$(ver-tmp))
+ver-chg := $(word 2,$(ver-tmp))
+ifeq ($(strip $(ver-chg)),)
+$(error No changes since $(ver-tag))
+endif
+VERSION := $(ver-tag)-$(ver-chg)-nightly1
+else
+VERSION := $(shell sed 's/.*(1://;s/).*//;1q' debian/changelog)
+endif
 
 release: FORCE
 	md5sum $O/*/* >> $O/md5sum.txt
@@ -25,8 +35,6 @@ nightly: release FORCE
 
 ifeq ($(MAKECMDGOALS),nightly)
 release-deps: debian/changelog
-version-tag := $(shell git describe | cut -d- -f1)
-VERSION := $(VERSION)-nightly1
 endif
 
 # log-paths is used to filter-out uninteresting changes
@@ -35,7 +43,7 @@ log-date = $(shell date -R)
 
 debian/changelog: FORCE
 	/bin/echo -e 'bluecherry (1:$(VERSION)) $(DIST); urgency=low\n' > $@
-	git log --pretty=format:'  * %s' ^$(version-tag) HEAD -- $(log-paths) >> $@
+	git log --pretty=format:'  * %s' ^$(ver-tag) HEAD -- $(log-paths) >> $@
 	/bin/echo -e '\n\n -- $(MAINTAINER)  $(log-date)\n' >> $@
 	git show 'HEAD:$@' >> $@
 


### PR DESCRIPTION
Now version is extracted from the changelog for normal releases.

Regarding nightly builds, it adds some sanity checking. The ver-chg
variable is the number of changes since the last release.
