### PR TITLE
thread fixes in one patch

### DIFF
--- a/server/bc-server.cpp
+++ b/server/bc-server.cpp
@@ -22,6 +22,10 @@ extern "C" {
 #include "bc-server.h"
 #include "rtsp.h"
 
+/* Global Mutexes */
+pthread_mutex_t mutex_global_sched;
+pthread_mutex_t mutex_streaming_setup;
+
 static std::vector<bc_record*> bc_rec_list;
 
 static int max_threads;
@@ -105,6 +109,14 @@ void bc_status_component_error(const char *error, ...)
 	}
 
 	va_end(args);
+}
+
+static void bc_initialize_mutexes()
+{
+	pthread_mutex_init(&mutex_global_sched,
+			   (pthread_mutexattr_t *) NULL);
+	pthread_mutex_init(&mutex_streaming_setup,
+			   (pthread_mutexattr_t *) NULL);
 }
 
 static const char *component_string(bc_status_component c)
@@ -259,8 +271,11 @@ static int bc_check_globals(void)
 
 	if (dbres && !bc_db_fetch_row(dbres)) {
 		const char *sched = bc_db_get_val(dbres, "value", NULL);
-		if (sched)
+		if (sched) {
+			pthread_mutex_lock(&mutex_global_sched);
 			strlcpy(global_sched, sched, sizeof(global_sched));
+			pthread_mutex_unlock(&mutex_global_sched);
+		}
 	} else {
 		/* Default to continuous record */
 		memset(global_sched, 'C', sizeof(global_sched));
@@ -788,6 +803,9 @@ int main(int argc, char **argv)
 	}
 
 	bc_log(Info, "Started Bluecherry daemon");
+
+	/* Mutex */
+	bc_initialize_mutexes();
 
 	rtsp_server *rtsp = new rtsp_server;
 	rtsp->setup(7002);

--- a/server/bc-server.h
+++ b/server/bc-server.h
@@ -15,6 +15,10 @@ extern "C" {
 #include "g723-dec.h"
 }
 
+/* Global Mutexes */
+extern pthread_mutex_t mutex_global_sched;
+extern pthread_mutex_t mutex_streaming_setup;
+
 /* Maximum length of recording */
 #define BC_MAX_RECORD_TIME 900
 

--- a/server/bc-thread.cpp
+++ b/server/bc-thread.cpp
@@ -86,7 +86,11 @@ static void check_schedule(struct bc_record *bc_rec)
 	time(&t);
 	localtime_r(&t, &tm);
 
+	/* Update global sched */
+	pthread_mutex_lock(&mutex_global_sched);
 	sched_new = schedule[tm.tm_hour + (tm.tm_wday * 24)];
+	pthread_mutex_unlock(&mutex_global_sched);
+
 	if (bc_rec->sched_cur != sched_new) {
 		if (!bc_rec->sched_last)
 			bc_rec->sched_last = bc_rec->sched_cur;
@@ -212,8 +216,9 @@ void bc_record::run()
 
 		/* Send packet to streaming clients */
 		if (bc_streaming_is_active(this))
-			bc_streaming_packet_write(this, packet);
-
+			if (bc_streaming_packet_write(this, packet) == -1) {
+				goto error;
+			}
 		continue;
 error:
 		sleep(10);


### PR DESCRIPTION
The server have a few global variables which are not protected
and face some race conditions and sometimes it leads to a deadlock
in the core.

This patch adds some protection when accessing those variables.

Signed-off-by: Eduardo Silva eduardo@corp.bluecherry.net

server: fix code indentation in bc-thread code

Signed-off-by: Eduardo Silva eduardo@corp.bluecherry.net
