### PR TITLE
RFC: Fix event tables constraints to allow straightforward cleanup of the DB

### DIFF
--- a/misc/sql/mysql-upgrade/1:2.1.5-1
+++ b/misc/sql/mysql-upgrade/1:2.1.5-1
@@ -1,0 +1,22 @@
+-- Update event tables constraints to use ON DELETE CASCADE, to allow
+-- straightforward deletion of records on media cleanup routine.
+START TRANSACTION;
+ALTER TABLE EventsCam DROP CONSTRAINT EventsCam_ibfk_1;
+ALTER TABLE EventsCam ADD CONSTRAINT fk_media_id
+      FOREIGN KEY (media_id) REFERENCES Media(id)
+      ON DELETE CASCADE;
+COMMIT;
+
+START TRANSACTION;
+ALTER TABLE EventComments DROP CONSTRAINT EventComments_ibfk_1;
+ALTER TABLE EventComments ADD CONSTRAINT fk_event_id
+      FOREIGN KEY (event_id) REFERENCES EventsCam(id)
+      ON DELETE CASCADE;
+COMMIT;
+
+START TRANSACTION;
+ALTER TABLE EventTags DROP CONSTRAINT EventTags_ibfk_1;
+ALTER TABLE EventTags ADD CONSTRAINT fk_event_id
+      FOREIGN KEY (event_id) REFERENCES EventsCam(id)
+      ON DELETE CASCADE;
+COMMIT;

--- a/misc/sql/mysql/6-events.sql
+++ b/misc/sql/mysql/6-events.sql
@@ -41,7 +41,8 @@ CREATE TABLE EventsCam (
 	archive boolean NOT NULL DEFAULT FALSE,	-- archive the event's video/audio?
 	media_id integer,
 	details text DEFAULT NULL,
-	FOREIGN KEY (media_id) REFERENCES Media(id),
+	CONSTRAINT fk_media_id FOREIGN KEY (media_id) REFERENCES Media(id)
+		ON DELETE CASCADE,
 	FOREIGN KEY (level_id) REFERENCES EventLevels(id),
         FOREIGN KEY (device_id) REFERENCES Devices(id),
         FOREIGN KEY (type_id) REFERENCES EventTypesCam(id)
@@ -66,7 +67,8 @@ CREATE TABLE EventComments (
 	event_id integer,
 	user_id integer,
 	comment varchar(160),
-	FOREIGN KEY (event_id) REFERENCES EventsCam(id),
+	CONSTRAINT fk_event_id FOREIGN KEY (event_id) REFERENCES EventsCam(id)
+		ON DELETE CASCADE,
 	FOREIGN KEY (user_id) REFERENCES Users(id)
 );
 
@@ -91,6 +93,7 @@ CREATE TABLE EventTags (
 	event_id integer,
 	tag_id varchar(10),
 	user_id integer,
-	FOREIGN KEY (event_id) REFERENCES EventsCam(id),
+	CONSTRAINT fk_event_id FOREIGN KEY (event_id) REFERENCES EventsCam(id)
+		ON DELETE CASCADE,
 	FOREIGN KEY (user_id) REFERENCES Users(id)
 );

--- a/server/bc-server.cpp
+++ b/server/bc-server.cpp
@@ -462,9 +462,9 @@ static int bc_cleanup_media()
 		}
 
 		removed++;
-		if (__bc_db_query("UPDATE Media SET filepath='',size=0 "
-		                  "WHERE id=%d", id)) {
-			bc_status_component_error("Database error during media cleanup");
+
+		if (__bc_db_query("DELETE FROM Media WHERE id=%d", id)) {
+			bc_status_component_error("Database error during Media cleanup");
 		}
 
 		/* Every four files removed check if enough space has been


### PR DESCRIPTION
NOTE: Not tested properly. Downgrading and upgrading again might fail (haven't checked the script).
