### PR TITLE
add the watchdog to solve the libav crash

### DIFF
--- a/server/bc-server.h
+++ b/server/bc-server.h
@@ -65,6 +65,7 @@ public:
 	pthread_t		thread;
 
 	struct watchdog		watchdog;
+	bool      		watchdog_flag;
 
 	/* Event/Media handling */
 	bc_event_cam_t          event;

--- a/server/recorder.h
+++ b/server/recorder.h
@@ -2,6 +2,7 @@
 #define RECORDER_H
 
 #include "stream_elements.h"
+#include "watchdog.h"
 
 struct AVCodecContext;
 struct bc_record;
@@ -18,6 +19,7 @@ public:
 	void destroy();
 	void run();
 
+	void start_thread();
 private:
 	int device_id;
 	bool destroy_flag;
@@ -33,6 +35,12 @@ private:
 	std::string media_file_path(time_t start);
 	void recording_end();
 	void do_error_event(bc_event_level_t level, bc_event_cam_type_t type);
+
+	pthread_t m_thread;
+	bool m_processing;
+	struct watchdog	m_watchdog;
+	static void watchdog_cb(struct watchdog *w);
+	static void thread_cleanup(void *data);
 };
 
 #endif

--- a/server/streaming.cpp
+++ b/server/streaming.cpp
@@ -81,10 +81,12 @@ void bc_streaming_destroy(struct bc_record *bc_rec)
 		av_free(buf);
 	}
 
-	for (unsigned int i = 0; i < ctx->nb_streams; ++i) {
-		avcodec_close(ctx->streams[i]->codec);
-		av_freep(&ctx->streams[i]->codec);
-		av_freep(&ctx->streams[i]);
+	if (!bc_rec->watchdog_flag) {
+		for (unsigned int i = 0; i < ctx->nb_streams; ++i) {
+			avcodec_close(ctx->streams[i]->codec);
+			av_freep(&ctx->streams[i]->codec);
+			av_freep(&ctx->streams[i]);
+		}
 	}
 
 	av_free(ctx);


### PR DESCRIPTION
1. added the recorder watchdog. 
   when the bad packet arrived from camera, recorder module was crashed sometimes.
2. added the watchdog flag while watchdog is running.
   when the libav was crashed, we don't close the libav streaming codec in the "bc_streaming_destroy" function.
