### PR TITLE
pre-post recording problem

### DIFF
--- a/server/bc-thread.cpp
+++ b/server/bc-thread.cpp
@@ -185,6 +185,9 @@ void bc_record::run()
 				rec = new recorder(this);
 				rec->set_logging_context(log);
 				rec->set_recording_type(BC_EVENT_CAM_T_MOTION);
+
+				rec->set_buffer_time(cfg.prerecord);
+
 				m_handler->connect(rec);
 				std::thread rec_th(&recorder::run, rec);
 				rec_th.detach();

--- a/server/motion_handler.cpp
+++ b/server/motion_handler.cpp
@@ -102,7 +102,7 @@ void motion_handler::run()
 			recording = true;
 		}
 
-		if (!triggered && recording && buffer.back().ts_monotonic - last_motion > postrecord_time) {
+		if (!triggered && recording && buffer.back().ts_monotonic - last_motion > postrecord_time - prerecord_time) {
 			bc_log(Debug, "motion: pause recording");
 			recording = false;
 		}

--- a/server/recorder.cpp
+++ b/server/recorder.cpp
@@ -217,3 +217,8 @@ void recorder::do_error_event(bc_event_level_t level, bc_event_cam_type_t type)
 	}
 }
 
+void recorder::set_buffer_time(int prerecord)
+{
+	buffer.set_duration(prerecord);
+}
+

--- a/server/recorder.h
+++ b/server/recorder.h
@@ -14,6 +14,7 @@ public:
 	virtual ~recorder();
 
 	void set_recording_type(bc_event_cam_type_t type);
+	void set_buffer_time(int prerecord);
 
 	void destroy();
 	void run();


### PR DESCRIPTION
1. set the buffer's duration for a pre-recording.
2. calculate the packet's time for a post-recording(using pre-time and post-time).

Fixes #127.
