### PR TITLE
Use the correct username in the logrotate config file on debian

### DIFF
--- a/misc/postinstall.sh
+++ b/misc/postinstall.sh
@@ -110,6 +110,12 @@ case "$1" in
 			chown root:bluecherry /var/log/bluecherry.log
 		fi
 		chmod 640 /var/log/bluecherry.log
+		
+		# Use the correct user for rsyslog under debian
+		if [[ $(cat /etc/os-release | grep "^ID=" | grep debian) ]]
+		then
+			sed -i 's/ syslog / root /' /etc/logrotate.d/bluecherry
+		fi
 
 		if [[ $IN_DEB ]]
 		then


### PR DESCRIPTION
On debian logrotate was unable to rotate the /var/log/bluecherry.log file on system without the "syslog" user. On a new debian install the log service rsyslog runs under the root user and does not create the syslog user. The logrotate file was updated to reflect that.

root@deb:/etc/logrotate.d# logrotate /etc/logrotate.conf
error: bluecherry:8 unknown user 'syslog'
error: found error in /var/log/bluecherry.log
, skipping
root@deb:/etc/logrotate.d#

Related issue https://github.com/bluecherrydvr/bluecherry-apps-issues/issues/157