### PR TITLE
Fix Bug 368. Moves error message instructions for storage to main pag…

### DIFF
--- a/www/lib/lang.php
+++ b/www/lib/lang.php
@@ -436,12 +436,9 @@ define('STRAGE_HEADER', 'Manage storage locations');
 define('ADD_LOCATION', 'Add location');
 define('LOCATION', 'Folder:');
 define('STORAGE_INFO_MESSAGE', 'Please note that if you add a new storage location, you need to make sure that: <br /> - folder exists <br /> - folder is empty <br /> - folder belongs to user bluecherry, group bluecherry.');
-define('DIR_DOES_NOT_EXIST_OR_NOT_READABLE', 'Server could not open the specified directory "<b>%PATH%</b>", please make sure it exists and the server can connect to it by running these commands in the terminal: <br /><br />
-		To create directory run: "sudo mkdir -p %PATH%" <br />
-		To set permissions run: "sudo chmod 770 %PATH%; sudo chown bluecherry:bluecherry -R %PATH%".
+define('DIR_DOES_NOT_EXIST_OR_NOT_READABLE', 'Server could not open the specified directory "<b>%PATH%</b>". See Note 2.
 	');
-define('DIR_NOT_READABLE', 'Specified directory exists, but is not readable, please make sure that the server has permissions to access it by running these commands in the terminal:<br /><br />
-		To set permissions run: "sudo chmod 770 %PATH%; sudo chown bluecherry:bluecherry -R %PATH%".
+define('DIR_NOT_READABLE', 'Specified directory "<b>%PATH%</b>" exists, but is not readable. See Note 2.
 	');
 define('DIR_NOT_EMPTY', 'Specified directory is not empty, all contents will be deleted after it is added.');
 define('DIR_OK', 'Specified directory exists and is writable. Click "save" to add this location.');

--- a/www/template/ajax/storage.php
+++ b/www/template/ajax/storage.php
@@ -60,9 +60,11 @@
                 <td colspan="5"><div class="alert alert-warning"><i class="fa fa-warning fa-fw"></i> <?php echo "Note 1:  A storage directory is accessible only if the permissions on each of the directories in the path prefix of pathname grant search (i.e., execute) access to the user id that the web server runs as (usually 'www-data').  If any directory  is  inaccessible,  then
        the directory is not readable, even if correct permissions and ownership are set on this directory. This is a frequent issue with automounted external storage like USB drives."; ?></div></td>
             </tr>
-
 	    <tr class="table-storage-tr-info">
-                <td colspan="5"><div class="alert alert-warning"><i class="fa fa-warning fa-fw"></i> <?php echo "Note 2:  It is recommended to mount network storage with sync option and disabled cache (option cache=none for CIFS)."; ?></div></td>
+                <td colspan="5"><div class="alert alert-warning"><i class="fa fa-warning fa-fw"></i> <?php echo 'Note 2:  Before adding a new folder, ensure that the: <br /> - folder exists <br /> - folder is empty <br /> - folder belongs to user bluecherry, group bluecherry. <br /><br /> To create directory run: "sudo mkdir -p &lt;your path&gt;" <br /> To set permissions run: "sudo chmod 770 &lt;your path&gt; <br /> To set ownership run: "sudo chown -R bluecherry:bluecherry &lt;your path&gt;".'; ?></div></td>
+            </tr>
+	    <tr class="table-storage-tr-info">
+                <td colspan="5"><div class="alert alert-warning"><i class="fa fa-warning fa-fw"></i> <?php echo "Note 3:  It is recommended to mount network storage with sync option and disabled cache (option cache=none for CIFS)."; ?></div></td>
             </tr>
             <?php } ?>
 


### PR DESCRIPTION

![message](https://user-images.githubusercontent.com/17209731/71770343-e1eb7a00-2f01-11ea-8c41-cb61f9140f96.png)
![Notes](https://user-images.githubusercontent.com/17209731/71770345-e1eb7a00-2f01-11ea-9758-c5d3afda7dc4.png)

…e for easier copy paste by user. Error message refers to Note now.