### PR TITLE
Check motion event type before firing webhook

### DIFF
--- a/www/lib/mailer.php
+++ b/www/lib/mailer.php
@@ -112,11 +112,15 @@ if ($argv[1] == "motion_event") {
 	#get device details
 	$device = data::getObject('Devices', 'id', $device_id);
 
-	webhook_trigger('motion_event', $device_id, array(
-		'device_id' => $device_id,
-		'device_name' => $device[0]['device_name'],
-		'dvr_name' => $global_settings->data['G_DVR_NAME']
-	));
+	$event_cam = data::getObject('EventsCam', 'media_id', $argv[2]);
+
+	if ($event_cam[0]['type_id'] == 'motion') {
+		webhook_trigger('motion_event', $device_id, array(
+			'device_id' => $device_id,
+			'device_name' => $device[0]['device_name'],
+			'dvr_name' => $global_settings->data['G_DVR_NAME']
+		));
+	}
 
 } else if ($argv[1] == "device_state") {
 	$device_id = $argv[2];


### PR DESCRIPTION
Currently a webhook fires for both a continuous recording and an actual motion event. Query the camera event and verify its type is `motion` before firing.

## Testing
I have spun up a small webserver that dumps whatever requests it gets from the webhook and am able to validate I now only see motion events and not constant continuous recording rollovers. I didn't find any test suite to add to for this. I'll be monitoring this change in my own setup here for the next few days.

## Further Questions
I realize I am coming into this pretty blind, but I think a better place to check this might be here: https://github.com/bluecherrydvr/bluecherry-apps/blob/abfd9979f1ff822442790a8428670921beaf18f3/server/recorder.cpp#L168

However I'm not able to easily build the C++ portion of Bluecherry because I run Fedora :grimacing:. I see there seems to be CentOS support, so perhaps adding Fedora wouldn't be too difficult. But for now, I figured I'd toss this out there to get the ball rolling, because I really want accurate webhook functionality for my own setup!