### PR TITLE
Increase Media.size limit to fix SQL errors

### DIFF
--- a/misc/sql/mysql-upgrade/3000010/increase_media_size_max.sh
+++ b/misc/sql/mysql-upgrade/3000010/increase_media_size_max.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo '
+alter table Media modify size bigint;
+' | mysql -h"$host" -D"$dbname" -u"$user" -p"$password"
+
+exit 0

--- a/misc/sql/schema_mysql.sql
+++ b/misc/sql/schema_mysql.sql
@@ -221,7 +221,7 @@ CREATE TABLE `Media` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `start` int(11) NOT NULL,
   `end` int(11) NOT NULL DEFAULT '0',
-  `size` int(11) DEFAULT NULL,
+  `size` bigint(20) DEFAULT NULL,
   `device_id` int(11) NOT NULL,
   `filepath` varchar(1024) NOT NULL,
   `archive` tinyint(1) NOT NULL DEFAULT '0',


### PR DESCRIPTION
Make `Media.size` a bigint rather than an INT. Fixes SQL "value out of range" errors that you start to see when setting continuous recording segment length to 1 hour or more.

## Validating
I'm not sure. I didn't find a way to run these migrations, someone advise?