### PR TITLE
Add 503 http status on db connect failure

### DIFF
--- a/www/lib/Reply.php
+++ b/www/lib/Reply.php
@@ -9,7 +9,6 @@ class Reply
         
         $res = json_encode($data);
 
-        //die($res);
         return $res;
     }
 
@@ -18,6 +17,8 @@ class Reply
         $data['status'] = $stat;
         $data['msg'] = $msg;
         $data['data'] = $data_tr;
+
+        http_response_code(503);
 
         die(self::ajax($data));
     }

--- a/www/lib/lib.php
+++ b/www/lib/lib.php
@@ -214,7 +214,7 @@ class database{
 
 	private function connect() {
 		$this->load_config();
-		$this->dblink = mysqli_connect($this->dbhost, $this->dbuser, $this->dbpassword, $this->dbname) or die(LANG_DIE_COULDNOTCONNECT);
+		$this->dblink = mysqli_connect($this->dbhost, $this->dbuser, $this->dbpassword, $this->dbname) or Reply::ajaxDie('service-unavailable-error', LANG_DIE_COULDNOTCONNECT);
 		mysqli_real_query($this->dblink, "set names utf8;");
 	}
 	public static function escapeString(&$string) {


### PR DESCRIPTION
The strong db coupling and the very early attempt to connect to the database makes it impossible, as is, to hit controllers without forcefully connecting to the database.
This PR makes use of the available Reply class to enforce http status code upon db connection failure.