### PR TITLE
Add aac_adtstoasc bitstream filter to bundled ffmpeg configuration

### DIFF
--- a/misc/BCMK
+++ b/misc/BCMK
@@ -77,6 +77,7 @@ libav/config.mak:
 		--enable-demuxer=rawvideo \
 		--enable-demuxer=concat \
 		\
+		--enable-bsf=aac_adtstoasc \
 		--enable-bsf=h264_mp4toannexb \
 		--enable-bsf=extract_extradata \
 		\


### PR DESCRIPTION
Some video sources with AAC audio exhibit this persisten error: "Error writing frame to recording: Bitstream filter not found". MP4 muxer uses this bitstream filter to write AAC.