### PR TITLE
Make sure pip-installed certbot gets upgraded on bluecherry package update

### DIFF
--- a/misc/postinstall.sh
+++ b/misc/postinstall.sh
@@ -415,7 +415,7 @@ case "$1" in
 		install_pip
 
 		# Install pip3 dependencies
-		/usr/local/bin/pip3 install --user setuptools_rust certbot certbot-dns-subdomain-provider
+		/usr/local/bin/pip3 install --user --upgrade setuptools_rust certbot certbot-dns-subdomain-provider
 		/usr/local/bin/pip3 install --user --upgrade pip
 		/usr/local/bin/pip3 install --user --upgrade cryptography
 	        /usr/local/bin/pip3 install pyopenssl --upgrade


### PR DESCRIPTION
This is to get it upgraded from a pre-2.7.0 version which exhibits a bug https://github.com/bluecherrydvr/bluecherry-apps/issues/629