### PR TITLE
WIP Deoccupy root's crontab

### DIFF
--- a/misc/cron/bluecherry-subdomain-cert-renewal
+++ b/misc/cron/bluecherry-subdomain-cert-renewal
@@ -7,7 +7,7 @@
 # |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
 # |  |  |  |  |
 # *  *  *  *  * user-name command to be executed
-*    * */5 *  *   root    certbot renew --config-dir=/usr/share/bluecherry/nginx-includes/letsencrypt/ >/dev/null 2>&1
+*    * */5 *  *   root    /usr/share/bluecherry/subdomain-cert-renewal &>/dev/null
 */5  *  *  *  *   root    curl -k https://localhost:7001/subdomainprovidercron >/dev/null 2>&1
 
 # vim: syntax=crontab

--- a/misc/cron/bluecherry-subdomain-cert-renewal
+++ b/misc/cron/bluecherry-subdomain-cert-renewal
@@ -1,0 +1,13 @@
+# This file is a part of bluecherry package.
+
+# .---------------- minute (0 - 59)
+# |  .------------- hour (0 - 23)
+# |  |  .---------- day of month (1 - 31)
+# |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
+# |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
+# |  |  |  |  |
+# *  *  *  *  * user-name command to be executed
+*    * */5 *  *   root    certbot renew --config-dir=/usr/share/bluecherry/nginx-includes/letsencrypt/ >/dev/null 2>&1
+*/5  *  *  *  *   root    curl -k https://localhost:7001/subdomainprovidercron >/dev/null 2>&1
+
+# vim: syntax=crontab

--- a/misc/postinstall.sh
+++ b/misc/postinstall.sh
@@ -419,7 +419,9 @@ case "$1" in
 	        /usr/local/bin/pip3 install pyopenssl --upgrade
 		
 		# Install crontabs for subdomain renewal and SSL renewal using certbot
-		crontab -l 2>/dev/null || true; printf "* * */5 * * certbot renew --config-dir=/usr/share/bluecherry/nginx-includes/letsencrypt/ >/dev/null 2>&1\n*/5 * * * * curl -k https://localhost:7001/subdomainprovidercron >/dev/null 2>&1\n" | crontab -
+		install --mode 600 cron/bluecherry-subdomain-cert-renewal /etc/cron.d
+		# Clean root's crontab from entries which we previously put there
+		crontab -l 2>/dev/null | grep -v 'bluecherry\|subdomainprovidercron' | crontab -
 
 
 		nginx -t 2>/dev/null > /dev/null

--- a/misc/subdomain-cert-renewal
+++ b/misc/subdomain-cert-renewal
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+
+# Suppress the output of the rest of the script.
+# To debug, redirect to a real file.
+exec &> /dev/null
+
+CERTBOT=/root/.local/bin/certbot
+if ! [[ -x "$CERTBOT" ]]; then
+    CERTBOT=certbot
+fi
+
+"$CERTBOT" renew --config-dir=/usr/share/bluecherry/nginx-includes/letsencrypt/

--- a/scripts/update_subdomain_certs.sh
+++ b/scripts/update_subdomain_certs.sh
@@ -51,11 +51,16 @@ chmod 600 $credentials
 # Generate certificates
 echo "Generating certs..."
 
-certbot certonly --non-interactive --agree-tos --work-dir=/tmp --logs-dir=/tmp \
+CERTBOT=/root/.local/bin/certbot
+if ! [[ -x "$CERTBOT" ]]; then
+    CERTBOT=certbot
+fi
+
+"$CERTBOT" certonly --non-interactive --agree-tos --work-dir=/tmp --logs-dir=/tmp \
     --config-dir=/usr/share/bluecherry/nginx-includes/letsencrypt/ \
-    --dns-subdomain-provider-credentials $credentials \
-    -m $email --authenticator dns-subdomain-provider \
-    -d $subdomain.bluecherry.app -v
+    --dns-subdomain-provider-credentials "$credentials" \
+    -m "$email" --authenticator dns-subdomain-provider \
+    -d "$subdomain".bluecherry.app -v
 
 rm $credentials
 


### PR DESCRIPTION
Put subdomain TLS certificate renewal jobs to a /etc/cron.d/ file with a name which clearly marks its association.

Unobtrusively clear root's crontab from the remaining job entries.