### PR TITLE
Update lib.php

### DIFF
--- a/www/lib/lib.php
+++ b/www/lib/lib.php
@@ -1364,7 +1364,7 @@ class Cameras
                                 // print_r($data);
 
                                 foreach($data['records'] as $camera) {
-                    $list[rawurlencode($manufacturer).' - '.$camera['id']] = $camera['fields']['Model'];
+                    $list[rawurlencode($manufacturer)] = $camera['fields']['Model'];
                                 }
 
                                 if(isset($data['offset']))


### PR DESCRIPTION
Remove unneeded ID number, we just need the manufacturer name

Fixes #647 

We were pulling the following json via API...however were added the Manufactuer AND the ID (for unknown reasons) which was being inserted into the database like 'IP Camera - recpSlTQIiaJez87D' which should never have happened and the model insert into mysql was too long anyway causing an ajax error.

```
{
	"id": "recpSlTQIiaJez87D",
	"createdTime": "2017-08-12T02:06:43.000Z",
	"fields": {
		"ManufacturerLink": [
			"recpeE5rOIW7SRmsC"
		],
		"id": 967,
		"JPEG path": "cgi-bin/guest/Video.cgi?media=JPEG",
		"Model": "Default",
		"Manufacturer": [
			"IP Camera"
		],
		"RTSP path fixed": "/"
	}
}
```
