### PR TITLE
Prefer TCP again

### DIFF
--- a/lib/lavf_device.h
+++ b/lib/lavf_device.h
@@ -52,7 +52,6 @@ public:
 private:
 	char url[1024];
 	int rtp_protocol = RTP_PROTOCOL_AUTO;
-	bool tcp_fallback = false;
 	char error_message[512];
 
 	AVFormatContext *ctx;


### PR DESCRIPTION
This changes the behaviour of "Protocol" option of device configuration, which affects how the source RTSP stream is being consumed.

Historically, TCP was preferred.
Then, since
01bac09d5caf ("Refactored input device and added option to select AUTO rtp protocol") UDP with fallback to TCP became the default ("AUTO" mode). This makes picture in recordings prone to smearing, so it was decided to switch back to TCP by default.

Previously, fallback to TCP was done in our code; this commit makes use of FFmpeg's "rtsp_flags=+prefer_tcp" which accomplishes suitable behaviour: try TCP, fallback to UDP.