### PR TITLE
mysql-upgrade: fix 3000011

### DIFF
--- a/misc/sql/mysql-upgrade/3000011/ip_manufacturer_lookup.sh
+++ b/misc/sql/mysql-upgrade/3000011/ip_manufacturer_lookup.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Enable live lookups of IP camera manufacturers (pulled from our API)
 
-echo '
-INSERT INTO `GlobalSettings` VALUES ('G_DATA_SOURCE','live');
-' | mysql -h"$host" -D"$dbname" -u"$user" -p"$password"
+echo "
+INSERT INTO GlobalSettings VALUES ('G_DATA_SOURCE','live');
+" | mysql -h"$host" -D"$dbname" -u"$user" -p"$password"
 
 exit 0


### PR DESCRIPTION
Quotes around literal strings disappeared at shell level, making MySQL think they are expressions.

Changed the outer quoting to double quotes and dropped the backticks around the table name.