### PR TITLE
www/ajax/discoverCameras.php: set NODE_PATH for js tool cmd

### DIFF
--- a/www/ajax/discoverCameras.php
+++ b/www/ajax/discoverCameras.php
@@ -175,7 +175,7 @@ class discoverCameras extends Controller {
         );
 
         $tools = Array(
-            "node /usr/share/bluecherry/onvif/discovery_json/node-onvif.js",
+            "NODE_PATH=/usr/share/nodejs/onvif/node_modules node /usr/share/bluecherry/onvif/discovery_json/node-onvif.js",
             "/usr/share/bluecherry/onvif/discovery_json/onvif_tool",
         );
         foreach ($tools as $tool) {


### PR DESCRIPTION
In bluecherry-node-onvif package, we bundle the dependencies necessary to avoid relying on packaging of all of them the Debian way.

The command "node .../discovery_json/node-onvif.js" doesn't work as it doesn't look for node_modules where we put them,
/usr/share/nodejs/onvif/node_modules .

This change passes NODE_PATH env var to `node` interpreter command, which is handled as expected by PHP's popen().