### PR TITLE
installer: fix mysql server installation for Debian 10

### DIFF
--- a/installer/v3.sh
+++ b/installer/v3.sh
@@ -113,12 +113,11 @@ buster_install()
     apt-get -y install gnupg sudo wget
     apt-get -y install python3-pip
     pip3 install --user --upgrade pip
-    wget -q https://repo.mysql.com/RPM-GPG-KEY-mysql-2023 -O- | apt-key add -
     wget -q https://dl.bluecherrydvr.com/key/bluecherry.asc -O- | apt-key add -
     : "${SRCLIST_URL:=https://dl.bluecherrydvr.com/sources.list.d/bluecherry-"$VERSION_CODENAME"-unstable.list}"
     wget --output-document=/etc/apt/sources.list.d/bluecherry-"$VERSION_CODENAME".list "$SRCLIST_URL"
     apt-get -y update
-    apt-get -y install mysql-server bluecherry
+    apt-get -y install default-mysql-server bluecherry
 }
 
 # Debian 11
@@ -126,13 +125,11 @@ bullseye_install()
 {
     apt-get -y update
     apt-get -y install gnupg sudo sudo python3-distutils wget
-    wget -q https://repo.mysql.com/RPM-GPG-KEY-mysql-2023 -O- | apt-key add -
     wget -q https://dl.bluecherrydvr.com/key/bluecherry.asc -O- | apt-key add -
     : "${SRCLIST_URL:=https://dl.bluecherrydvr.com/sources.list.d/bluecherry-"$VERSION_CODENAME"-unstable.list}"
     wget --output-document=/etc/apt/sources.list.d/bluecherry-"$VERSION_CODENAME".list "$SRCLIST_URL"
     apt-get -y update
     apt-get -y install mariadb-server bluecherry
-#   apt-get install mariadb-server
 }
 
 check_distro()


### PR DESCRIPTION
"mysql-server" package is not found in central Debian repos. We don't actually enable mysql.com repo, and we don't even want that, per https://github.com/bluecherrydvr/bluecherry-apps/issues/423 .

"default-mysql-server" package on Debian 10 installs mariadb-server-10.3.