### PR TITLE
Restart web server after it's added to bluecherry group

### DIFF
--- a/debian/bluecherry.preinst.template
+++ b/debian/bluecherry.preinst.template
@@ -56,6 +56,9 @@ case "$1" in
 				-g bluecherry -G audio,video bluecherry
 		fi
 		usermod -a -G video,audio,bluecherry,dialout,adm www-data || true
+		# For bluecherry group membership to take effect, restart web server.
+		# It might be not configured yet, so restart might fail. That's fine.
+		systemctl restart nginx || true
 
 		;;
 esac


### PR DESCRIPTION
The current problem is that running web requests immediately after install gives "Fatal error: could not read configuration file."