### PR TITLE
Feature/645 Test devices authentication

### DIFF
--- a/www/ajax/editip.php
+++ b/www/ajax/editip.php
@@ -20,12 +20,13 @@ class editip extends Controller {
 	    $id = intval($_POST['id']);
     	$camera = new ipCamera($id);
     	$result = $camera->edit($_POST);
-        $camera->checkConnection();
-    	data::responseJSON($result[0], array(
-            $result[1], 
-            str_replace(array("%TYPE%", "%TIME%"), array("RTSP", $camera->info['connection_status']['lastTimeChecked']), 
+    	$camera = new ipCamera($id); // Reinstance the object to update information
+        $camera->checkConnection(); // Test the connection
+    	data::responseJSON($result[0], $result[1],  array(
+            json_encode($camera->info['connection_status']),
+            str_replace("%TYPE%", str_replace("IP-", "", $camera->info['protocol']), 
                 $camera->info['connection_status']['success'] ? AIP_CONNECTION_SUCCESS : AIP_CONNECTION_FAIL)
-        ), json_encode($camera->info['connection_status']));
+        ));
     	exit();
     }
 
@@ -34,11 +35,11 @@ class editip extends Controller {
 	    $id = intval($_POST['id']);
     	$camera = new ipCamera($id);
         $camera->checkConnection();
-        data::responseJSON(10, array( 1 => str_replace( //-> 10 as status to avoid the "changes saved successfully" popup
-            array("%TYPE%", "%TIME%"), 
-            array("RTSP", $camera->info['connection_status']['lastTimeChecked']), 
-            $camera->info['connection_status']['success'] ? AIP_CONNECTION_SUCCESS : AIP_CONNECTION_FAIL)
-        ), json_encode($camera->info['connection_status'])); 
+        data::responseJSON(10, "", array(
+            json_encode($camera->info['connection_status']),
+            str_replace("%TYPE%", str_replace("IP-", "", $camera->info['protocol']), 
+                $camera->info['connection_status']['success'] ? AIP_CONNECTION_SUCCESS : AIP_CONNECTION_FAIL)
+        )); 
         exit();
     }
 }

--- a/www/ajax/editip.php
+++ b/www/ajax/editip.php
@@ -20,9 +20,25 @@ class editip extends Controller {
 	    $id = intval($_POST['id']);
     	$camera = new ipCamera($id);
     	$result = $camera->edit($_POST);
-    	data::responseJSON($result[0], $result[1]);
+        $camera->checkConnection();
+    	data::responseJSON($result[0], array(
+            $result[1], 
+            str_replace(array("%TYPE%", "%TIME%"), array("RTSP", $camera->info['connection_status']['lastTimeChecked']), 
+                $camera->info['connection_status']['success'] ? AIP_CONNECTION_SUCCESS : AIP_CONNECTION_FAIL)
+        ), json_encode($camera->info['connection_status']));
     	exit();
     }
+
+    public function postTest() 
+    {
+	    $id = intval($_POST['id']);
+    	$camera = new ipCamera($id);
+        $camera->checkConnection();
+        data::responseJSON(10, array( 1 => str_replace( //-> 10 as status to avoid the "changes saved successfully" popup
+            array("%TYPE%", "%TIME%"), 
+            array("RTSP", $camera->info['connection_status']['lastTimeChecked']), 
+            $camera->info['connection_status']['success'] ? AIP_CONNECTION_SUCCESS : AIP_CONNECTION_FAIL)
+        ), json_encode($camera->info['connection_status'])); 
+        exit();
+    }
 }
-
-

--- a/www/ajax/ipcameracheck.php
+++ b/www/ajax/ipcameracheck.php
@@ -44,13 +44,12 @@ class ipcameracheck extends Controller {
 
         $camera->checkConnection();
 
-        $status_message = '';
-        foreach($camera->info['connection_status'] as $type => $status){
-        	if ($status!='OK'){
-        		$status_message .= str_replace('%TYPE%', $type, constant('IP_ACCESS_STATUS_'.$status)).'<br /><br />';
-        	}
-        };
-
+        $status_message = str_replace( //-> 10 as status to avoid the "changes saved successfully" popup
+            array("%TYPE%", "%TIME%"), 
+            array("RTSP", $camera->info['connection_status']['lastTimeChecked']), 
+            $camera->info['connection_status']['success'] ? AIP_CONNECTION_SUCCESS : AIP_CONNECTION_FAIL
+        );
+        
         echo $status_message;
     }
 }

--- a/www/ajax/ipcameracheck.php
+++ b/www/ajax/ipcameracheck.php
@@ -44,11 +44,8 @@ class ipcameracheck extends Controller {
 
         $camera->checkConnection();
 
-        $status_message = str_replace( //-> 10 as status to avoid the "changes saved successfully" popup
-            array("%TYPE%", "%TIME%"), 
-            array("RTSP", $camera->info['connection_status']['lastTimeChecked']), 
-            $camera->info['connection_status']['success'] ? AIP_CONNECTION_SUCCESS : AIP_CONNECTION_FAIL
-        );
+        $status_message = str_replace("%TYPE%", str_replace("IP-", "", $camera->info['protocol']), 
+        $camera->info['connection_status']['success'] ? AIP_CONNECTION_SUCCESS : AIP_CONNECTION_FAIL);
         
         echo $status_message;
     }

--- a/www/lib/lang.php
+++ b/www/lib/lang.php
@@ -384,6 +384,10 @@ define('AIP_CHECK_ONVIF_PORT', 'ONVIF Probe & Autoconfigure');
 define('AIP_CHECK_ONVIF_SUCCESS', 'Successfull');
 define('AIP_CHECK_ONVIF_ERROR', 'Unsuccessful');
 define('AIP_LIMIT_ALLOWED_DEVICES', 'Could not add a camera, because exceeds the limit of the allowed devices.');
+define('AIP_TEST_CONNECTION', 'Test Connection');
+define('AIP_TEST_CONNECTION_MESSAGE', 'Test connection to IP Camera');
+define('AIP_CONNECTION_SUCCESS', 'Connection Successful using %TYPE%. Tested at %TIME%');
+define('AIP_CONNECTION_FAIL', 'Connection Unsuccessful using %TYPE%. Tested at %TIME%');
 
 # HLS configuration
 define('AIP_HLS_WINDOW_SIZE', 'HLS window size');

--- a/www/lib/lang.php
+++ b/www/lib/lang.php
@@ -386,8 +386,8 @@ define('AIP_CHECK_ONVIF_ERROR', 'Unsuccessful');
 define('AIP_LIMIT_ALLOWED_DEVICES', 'Could not add a camera, because exceeds the limit of the allowed devices.');
 define('AIP_TEST_CONNECTION', 'Test Connection');
 define('AIP_TEST_CONNECTION_MESSAGE', 'Test connection to IP Camera');
-define('AIP_CONNECTION_SUCCESS', 'Connection Successful using %TYPE%. Tested at %TIME%');
-define('AIP_CONNECTION_FAIL', 'Connection Unsuccessful using %TYPE%. Tested at %TIME%');
+define('AIP_CONNECTION_SUCCESS', 'Connection Successful using %TYPE%');
+define('AIP_CONNECTION_FAIL', 'Connection Unsuccessful using %TYPE%');
 
 # HLS configuration
 define('AIP_HLS_WINDOW_SIZE', 'HLS window size');

--- a/www/lib/lib.php
+++ b/www/lib/lib.php
@@ -772,10 +772,12 @@ class ipCamera{
 		ini_set('default_socket_timeout', 1);
 
 		$path = "";
+		$args = "";
 
 		switch($this->info['protocol'])  {
 			case 'IP-RTSP':
-				$path = '-rtsp_transport tcp "rtsp://'.((empty($this->info['rtsp_username'])) ? '' : $this->info['rtsp_username'].':'.$this->info['rtsp_password'].'@').$this->info['ipAddr'].':'.$this->info['port'].$this->info['rtsp'].'"';
+				$path = 'rtsp://'.((empty($this->info['rtsp_username'])) ? '' : $this->info['rtsp_username'].':'.$this->info['rtsp_password'].'@').$this->info['ipAddr'].':'.$this->info['port'].$this->info['rtsp'];
+				$args = array("-rtsp_flags +prefer_tcp", "-rtsp_transport tcp", "-rtsp_transport tcp")[$this->info['rtsp_rtp_prefer_tcp']];
 				break;
 			case 'IP-MJPEG': 
 				//FIXME: This is the old logic for testing MJPEG. Testing for MJPEG is currently not supported by the bundled ffprobe method used for RTSP
@@ -789,7 +791,7 @@ class ipCamera{
 
 		//-> '-stimeout' is measured in microseconds
 		$ffprobe_output = shell_exec(
-			"/usr/lib/bluecherry/ffprobe -stimeout 5000000 -hide_banner -show_format -show_streams -print_format json ".$path);
+			"/usr/lib/bluecherry/ffprobe -stimeout 5000000 -hide_banner -show_format -show_streams -print_format json ".$args. " " . escapeshellarg($path));
 
 		$rtsp_data = json_decode($ffprobe_output, true);
 

--- a/www/template/ajax/editip.php
+++ b/www/template/ajax/editip.php
@@ -14,13 +14,27 @@
 
 <div class="row">
     <div class="col-lg-12 col-md-12">
-        <form action="/ajax/editip.php" method="POST" class="form-horizontal">
-	        <input type="hidden" name="mode" value="editIp" />
-        	<input type="hidden" name="id" value="<?php echo $ipCamera->info['id']; ?>" />
+        <div class="panel panel-default">
+            <div class="panel-body">
 
-            <div class="panel panel-default">
-                <div class="panel-body">
-                    
+                <div class="form-group">
+                    <div class="col-lg-7 col-lg-offset-3 col-md-7 col-md-offset-2">
+                        <div id="connStat" class="alert alert-info"> 
+                            <span id="csText" style="line-height: 34px;"><?php echo AIP_TEST_CONNECTION_MESSAGE ?></span>
+                            <form action="/ajax/editip.php/test" method="POST" class="form-horizontal" style="display: inline;">
+                                <input type="hidden" name="mode" value="editIp" />
+                                <input type="hidden" name="id" value="<?php echo $ipCamera->info['id']; ?>" />
+                                <a type="submit" class="btn btn-warning send-req-form pull-right" data-func="testCameraLoadingHeader" data-func-after="testCameraConnection">
+                                    <i class="fa fa-check fa-fw"></i><?php echo AIP_TEST_CONNECTION ?>
+                                </a>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+                
+                <form action="/ajax/editip.php" method="POST" class="form-horizontal">
+                    <input type="hidden" name="mode" value="editIp" />
+                    <input type="hidden" name="id" value="<?php echo $ipCamera->info['id']; ?>" />
                     <div class="form-group">
                         <label class="col-lg-4 col-md-4 control-label"><?php echo VA_AUDIO_ENABLE; ?></label>
 
@@ -196,18 +210,16 @@
                             <input type="checkbox" name="debug_level" <?php echo ($ipCamera->info['debug_level']==1) ? 'checked' : ''; ?>  />
                         </div>
                     </div>
-                    
                     <div class="form-group">
                         <div class="col-lg-6 col-lg-offset-4 col-md-6 col-md-offset-4">
-                            <button class="btn btn-success send-req-form" type="submit"><i class="fa fa-check fa-fw"></i> <?php echo SAVE_CHANGES; ?></button>
+                            <button class="btn btn-success send-req-form"  data-func="testCameraLoadingHeader" data-func-after="testCameraConnection" type="submit">
+                                <i class="fa fa-check fa-fw"></i> <?php echo SAVE_CHANGES." & ".AIP_TEST_CONNECTION?>
+                            </button>
                         </div>
                     </div>
-
-                </div>
+                </form>
             </div>
-
-        
-        </form>
+        </div>
     </div>
 </div>
 

--- a/www/template/dist/js/editip.js
+++ b/www/template/dist/js/editip.js
@@ -1,0 +1,18 @@
+$(function() {
+    console.log("This loaded!");
+});
+
+function testCameraConnection(form, msg) {
+    let data = JSON.parse(msg.data);
+
+    $('#connStat').find('form').show();
+    if(data.success)
+        $('#connStat').removeClass().addClass('alert alert-success').find('span').html(msg.msg[1]);
+    else 
+        $('#connStat').removeClass().addClass('alert alert-danger').find('span').html(msg.msg[1]);
+}
+
+function testCameraLoadingHeader(form, msg) {
+    $('#connStat').removeClass().addClass('alert alert-warning').find('span').html('Testing...');
+    $('#connStat').find('form').hide();
+}

--- a/www/template/dist/js/editip.js
+++ b/www/template/dist/js/editip.js
@@ -1,13 +1,13 @@
 $(function() {
 });
 function testCameraConnection(form, msg) {
-    let data = JSON.parse(msg.data);
+    let data = JSON.parse(msg.data[0]);
 
     $('#connStat').find('form').show();
     if(data.success)
-        $('#connStat').removeClass().addClass('alert alert-success').find('span').html(msg.msg[1]);
+        $('#connStat').removeClass().addClass('alert alert-success').find('span').html(msg.data[1]);
     else 
-        $('#connStat').removeClass().addClass('alert alert-danger').find('span').html(msg.msg[1]);
+        $('#connStat').removeClass().addClass('alert alert-danger').find('span').html(msg.data[1]);
 }
 
 function testCameraLoadingHeader(form, msg) {

--- a/www/template/dist/js/editip.js
+++ b/www/template/dist/js/editip.js
@@ -1,7 +1,5 @@
 $(function() {
-    console.log("This loaded!");
 });
-
 function testCameraConnection(form, msg) {
     let data = JSON.parse(msg.data);
 

--- a/www/template/main_admin.php
+++ b/www/template/main_admin.php
@@ -322,6 +322,7 @@
     <script src="/template/dist/js/users.js"></script>
     <script src="/template/dist/js/devices.js"></script>
     <script src="/template/dist/js/addip.js"></script>
+    <script src="/template/dist/js/editip.js"></script>
     <script src="/template/dist/js/ptzpresetlist.js"></script>
     <script src="/template/dist/js/notifications.js"></script>
     <script src="/template/dist/js/statistics.js"></script>


### PR DESCRIPTION
Issue #645 requests that a feature be added to the Web UI that allows the end user to test and preview the connection status the their devices in an effort to make it more obvious when authentication settings and paths are not correct. 

This PR contains changes to the `editip` stack (`/templates/ajax/editip.php`, `/templates/dist/js/editip.js`, `/ajax/editip.php`) and the function already contained within `lib.php` titled `checkConnection()`. 

This function previously incorrectly made a request for the header data of http URLs and assumed a 200 code would mean that the authentication succeeded. This was not the case. These have been substituted for an `ffprobe` command with a timeout of 5 seconds.