### PR TITLE
www: fix warning about magic method visibility

### DIFF
--- a/www/lib/VarPub.php
+++ b/www/lib/VarPub.php
@@ -7,7 +7,7 @@ class VarPub
 
     private function __construct() {}
     private function __clone() {}
-    private function __wakeup() {}
+    public  function __wakeup() {}
     
     public static function get () 
     { 


### PR DESCRIPTION
PHP Warning:  The magic method VarPub::__wakeup() must have public visibility in www/lib/VarPub.php on line 10

Found by

    for x in $(find * -name '*.php' | grep -v /vendor/); do php -l $x; done