### PR TITLE
Change from lazy media storage cleanup to eager

### DIFF
--- a/server/bc-server.cpp
+++ b/server/bc-server.cpp
@@ -1189,12 +1189,12 @@ done:
 static int bc_check_media(void)
 {
 	int ret = 0;
-	bool storage_overloaded = true;
+	bool storage_overloaded = false;
 
 	/* If there's some space left, skip cleanup */
 	for (int i = 0; i < MAX_STOR_LOCS && media_stor[i].max_thresh; i++) {
-		if (is_storage_full(&media_stor[i]) != 1) {
-			storage_overloaded = false;
+		if (is_storage_full(&media_stor[i]) == 1) {
+			storage_overloaded = true;
 			break;
 		}
 	}


### PR DESCRIPTION
Before, if there was any storage location below max use threshold, the cleanup was skipped. This might cause problem described in https://github.com/bluecherrydvr/bluecherry-apps/issues/656 : as long as one location has space, others might fill up if used by other processes. The default location, /var/lib/bluecherry/recordings/ is usually on the system rootfs, where many services' and users' activities contribute to increasing the filesystem space used.

Now, the media cleanup happens if any of the storage locations is over the threshold.