### PR TITLE
Put stripped debug symbols back into bluecherry-dbg

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -13,14 +13,8 @@ RELEASE_NAME := $(shell ./scripts/build_helper/get_distro_release_name.sh)
 
 .PHONY: override_dh_strip debian/control
 
-# Don't build debug packages anymore
-
-#override_dh_strip:
-#	dh_strip --dbg-package=bluecherry-dbg
-
-#override_dh_installinit: sbin-start=$(wildcard /sbin/start)
-#override_dh_installinit:
-#	dh_installinit $(if $(sbin-start),--name=bluecherry)
+override_dh_strip:
+	dh_strip --dbg-package=bluecherry-dbg
 
 # Add support for systemd
 


### PR DESCRIPTION
Previously, the debug symbols were discarded by our building environment.

With this change, bluecherry-dbg packages again contain the debug symbols stripped from the built code.

Alternatively, we could change this code to "dh_strip --keep-debug" which adds 7 MB to bluecherry.deb, taking it from 28M to 35M.

The situation with instant access to crash backtraces enriched with debug symbols is now the following: the stack trace logged by bc-server itself lists the libraries for every stack frame, but not function names or line nubmers. This info is in the debug info shipped, but it is not used by glibc's backtrace() (wouldn't even if we avoid stripping overall).

The ways to use all the debug info are:

```sh
sudo -u bluecherry gdb -ex run -ex bt --args /usr/sbin/bc-server -s
```

```sh
sudo -u bluecherry rr record /usr/sbin/bc-server -s
sudo -u bluecherry rr replay # there: continue, bt...
```