### PR TITLE
Create /var/run/bluecherry in postinstall.sh

### DIFF
--- a/misc/postinstall.sh
+++ b/misc/postinstall.sh
@@ -173,6 +173,7 @@ case "$1" in
 		su bluecherry -c "chmod -R 770 /var/lib/bluecherry"
 		if [[ $IN_DEB ]]
 		then
+  			mkdir /var/run/bluecherry
 			chown -R bluecherry:bluecherry /var/run/bluecherry
 			su bluecherry -c "chmod -R 750 /var/run/bluecherry"
 		fi


### PR DESCRIPTION
postinstall.sh fails for Debian systems if /var/run/bluecherry doesn't exist....which is problematic because for whatever reason this directory isn't created (don't tell https://github.com/bluecherrydvr/bluecherry-apps/blob/aed298c912faec0884d4de7ed7b420eac34af0b7/debian/bluecherry.dirs#L4).