### PR TITLE
Fix error in user management web UI

### DIFF
--- a/www/lib/lib.php
+++ b/www/lib/lib.php
@@ -343,7 +343,7 @@ class user{
 		$this->info['access_ptz_list'] = (isset($this->info['access_ptz_list']) ? explode(',', $this->info['access_ptz_list']) : Array());
 		$this->info['access_device_list'] = (isset($this->info['access_device_list']) ? explode(',', $this->info['access_device_list']) : Array());
 	}
-	private function checkUserData($data, $new=false){
+	private static function checkUserData($data, $new=false){
 		if (empty($data['username']))	{ return NO_USERNAME;	};
 		if (empty($data['email']))		{ return NO_EMAIL;		};
 		if (empty($data['password']))	{ return NO_PASS;		};


### PR DESCRIPTION
What happens: submit a form for creation of a new user, get a blank page.

Seen on Debian 12.
Apparently older versions of PHP were forgiving in this case.
```
 ==> /var/log/nginx/bluecherry-error.log <==
 2024/08/31 23:01:42 [error] 380#380: *2 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught Error: Non-static method user::checkUserData() cannot be called statically in /usr/share/bluecherry/www/lib/lib.php:459
 Stack trace:
 #0 /usr/share/bluecherry/www/ajax/update.php(54): user::update()
 #1 /usr/share/bluecherry/www/ajax/update.php(30): update->newUser()
 #2 /usr/share/bluecherry/www/lib/Controller.php(124): update->postData()
 #3 /usr/share/bluecherry/www/lib/Route.php(75): Controller->start()
 #4 /usr/share/bluecherry/www/index.php(16): Route->start()
 #5 {main}
   thrown in /usr/share/bluecherry/www/lib/lib.php on line 459" while reading response header from upstream, client: 192.168.86.104, server: , request: "POST /ajax/update.php HTTP/1.1", upstream: "fastcgi://unix:/etc/alternatives/php-fpm.sock:", host: "192.168.86.136:7001", referrer: "https://192.168.86.136:7001/users?id=new"

 ==> /var/log/nginx/bluecherry-access.log <==
 192.168.86.104 - - [31/Aug/2024:23:01:42 +0000] "POST /ajax/update.php HTTP/1.1" 500 5 "https://192.168.86.136:7001/users?id=new" "Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0"
```