### PR TITLE
Create /var/run/bluecherry in postinstall.sh

### DIFF
--- a/misc/postinstall.sh
+++ b/misc/postinstall.sh
@@ -173,6 +173,7 @@ case "$1" in
 		su bluecherry -c "chmod -R 770 /var/lib/bluecherry"
 		if [[ $IN_DEB ]]
 		then
+			mkdir -p /var/run/bluecherry
 			chown -R bluecherry:bluecherry /var/run/bluecherry
 			su bluecherry -c "chmod -R 750 /var/run/bluecherry"
 		fi


### PR DESCRIPTION
postinstall.sh fails for Debian systems if /var/run/bluecherry doesn't exist.

For unclear reasons it sometimes doesn't exist.

See https://forums.bluecherrydvr.com/t/installation-error-on-var-run-bluecherry/891