### PR TITLE
Make continuous recording handle bad timestamps gracefully

### DIFF
--- a/server/media_writer.cpp
+++ b/server/media_writer.cpp
@@ -109,6 +109,10 @@ bool media_writer::write_packet(const stream_packet &pkt)
 	if (re < 0)
 	{
 		bc_avlog(re, "Error writing frame to recording");
+		if (re == AVERROR(EINVAL)) {
+			bc_log(Error, "Error writing frame to recording. Likely timestamping problem. Ignoring.");
+			return true;
+		}
 		return false;
 	}
 

--- a/server/media_writer.h
+++ b/server/media_writer.h
@@ -25,13 +25,8 @@ protected:
 	AVStream *audio_st = NULL;
 	std::string recording_path;
 
-	/* Base PTS value for the start of the recording. This assumes that all streams
-	 * share a time_base of AV_TIME_BASE, and 0 represents the same instant across all
-	 * streams. This is set automatically by the first written packet. */
-	int64_t last_video_pts = 0;
-	int64_t last_video_dts = 0;
-	int64_t last_audio_pts = 0;
-	int64_t last_audio_dts = 0;
+	/* Control monotonicity of timestamps we feed to muxer, the same way as in ffmpeg_mux.c in ffmpeg.*/
+	int64_t last_mux_dts[2] = {0, 0};
 };
 
 class snapshot_writer


### PR DESCRIPTION
The user-visible effect is that the recordings stick to the prescribed duration rather than randomly cut short.
The problem was that bad timestamps (situation which also occurs when just using ffmpeg) were attempted to be handled gracefully but were not done exactly right.