### PR TITLE
Prevent media_duration warnings and null values from events API

### DIFF
--- a/www/ajax/events/eventsIndex.php
+++ b/www/ajax/events/eventsIndex.php
@@ -125,7 +125,7 @@ class eventsIndex extends Controller {
                     $entry['content'] = array(
                         'media_id' => $item['media_id'],
                         'media_size' => $item['media_size'],
-                        'media_duration' => $item['media_duration'],
+                        'media_duration' => $item['video_duration'],
                         'content' => (!empty($_SERVER['HTTPS']) ? 'https' : 'http') . '://' . $_SERVER['HTTP_HOST'] . '/media/request.php?id=' . $item['media_id']
                     );
                 }

--- a/www/ajax/events/eventsIndex.php
+++ b/www/ajax/events/eventsIndex.php
@@ -18,7 +18,7 @@ class eventsIndex extends Controller {
         $events_portion = 5000;
 
         $query = "SELECT EventsCam.*, Media.size AS media_size, Media.start, Media.end, Devices.device_name, ((Media.size>0 OR Media.end=0) AND Media.filepath!='') AS media_available, ".
-            "IFNULL(TIMESTAMPDIFF(SECOND, Media.start, Media.end), 0) AS video_duration ".
+            "IFNULL(TIMESTAMPDIFF(SECOND, Media.start, Media.end), 0) AS media_duration ".
             "FROM EventsCam ".
             "LEFT JOIN Media ON (EventsCam.media_id=Media.id) ".
             "LEFT JOIN Devices ON (EventsCam.device_id=Devices.id) ".
@@ -125,7 +125,7 @@ class eventsIndex extends Controller {
                     $entry['content'] = array(
                         'media_id' => $item['media_id'],
                         'media_size' => $item['media_size'],
-                        'media_duration' => $item['video_duration'],
+                        'media_duration' => $item['media_duration'],
                         'content' => (!empty($_SERVER['HTTPS']) ? 'https' : 'http') . '://' . $_SERVER['HTTP_HOST'] . '/media/request.php?id=' . $item['media_id']
                     );
                 }

--- a/www/ajax/events/eventsIndex.php
+++ b/www/ajax/events/eventsIndex.php
@@ -8,6 +8,7 @@ class eventsIndex extends Controller {
         $this->chAccess('backup');
     }
 
+    // This function handles API endpoint /events/ used by client app.
     public function getData()
     {
         $current_user = $this->user;


### PR DESCRIPTION
We don't use media_duration, we use video_duration!

PHP message: PHP Notice:  Undefined index: media_duration in /usr/share/bluecherry/www/ajax/events/eventsIndex.php on line 128

root@fvi-bcdvr1:/usr/share/bluecherry/www/ajax/events# grep "media_duration" /var/log/nginx/bluecherry-error.log |wc -l 243107