### PR TITLE
Device logging updates

### DIFF
--- a/lib/lavf_device.cpp
+++ b/lib/lavf_device.cpp
@@ -111,12 +111,21 @@ int lavf_device::start()
 	int re = avformat_open_input(&ctx, url, input_fmt, &avopt_open_input);
 	av_dict_free(&avopt_open_input);
 
-	if (re != 0)
-	{
+	if (re != 0) {
 		av_strerror(re, error_message, sizeof(error_message));
-		bc_log(Error, "Failed to open stream. Error: %d (%s)", re, error_message);
-		ctx = NULL;
-		return -1;
+		char safe_url[512];
+    		strlcpy(safe_url, url, sizeof(safe_url));
+    		// Strip the username and password from the Find the @ symbol that separates credentials from host
+    		char *at_pos = strchr(safe_url, '@');
+    		if (at_pos && strncmp(safe_url, "rtsp://", 7) == 0) {
+        		// Move everything after @ to just after the rtsp://
+        	memmove(safe_url + 7, at_pos + 1, strlen(at_pos + 1) + 1);
+	}
+
+		bc_log(Error, "Failed to open stream for device %s Error: %d (%s) (** login credentials removed **)",
+           		safe_url, re, error_message);
+    		ctx = NULL;
+    	return -1;
 	}
 
 	AVDictionary *avopt_find_stream_info = NULL;

--- a/lib/lavf_device.cpp
+++ b/lib/lavf_device.cpp
@@ -115,10 +115,9 @@ int lavf_device::start()
 		av_strerror(re, error_message, sizeof(error_message));
 		char safe_url[512];
     		strlcpy(safe_url, url, sizeof(safe_url));
-    		// Strip the username and password from the Find the @ symbol that separates credentials from host
+    		/* Strip the username and password from the Find the @ symbol that separates credentials from host */
     		char *at_pos = strchr(safe_url, '@');
     		if (at_pos && strncmp(safe_url, "rtsp://", 7) == 0) {
-        		// Move everything after @ to just after the rtsp://
         	memmove(safe_url + 7, at_pos + 1, strlen(at_pos + 1) + 1);
 	}
 


### PR DESCRIPTION
This adds more verbose logging to bluecherry.log by showing the URL and path of the camera that is failing.  

```
Dec 28 17:45:49 7007cams bc-server[879285]: E(): Failed to open stream for device rtsp://192.168.86.198:554/h264Preview_01_sub  Error: -111 (Connection refused) (** login credentials removed **)
```