### PR TITLE
Set thread names

### DIFF
--- a/lib/BCMK
+++ b/lib/BCMK
@@ -7,7 +7,7 @@ endif
 
 LDFLAGS		+= -lconfig -lm -lrt -lbsd $(shell pkg-config --libs libcurl)
 LDFLAGS		+= -lavutil -lavformat -lavcodec -lpugixml
-CFLAGS		+= -fPIC -DETCDIR="\"$(etc_dir)\"" $(shell pkg-config --cflags libcurl)
+CFLAGS		+= -fPIC -DETCDIR="\"$(etc_dir)\"" $(shell pkg-config --cflags libcurl) $(shell pkg-config --cflags libbsd)
 
 SOLIB		= libbluecherry.so
 SOLIBVER	= $(SOLIB).0

--- a/lib/bc-stats.cpp
+++ b/lib/bc-stats.cpp
@@ -425,6 +425,7 @@ void bc_stats::display()
 
 void bc_stats::monithoring_thread()
 {
+    pthread_setname_np(pthread_self(), "MONITORING");
     while (!__sync_add_and_fetch(&_cancel, 0))
     {
         update_mem_info();

--- a/lib/stream_elements.cpp
+++ b/lib/stream_elements.cpp
@@ -1,7 +1,8 @@
 #include "stream_elements.h"
 
 stream_source::stream_source(const char *n)
-	: name(n)
+	: name(n),
+	thread_name({0,})
 {
 }
 
@@ -48,7 +49,8 @@ void stream_source::disconnect(stream_consumer *child)
 }
 
 stream_consumer::stream_consumer(const char *n)
-	: name(n), output_source(0), connected_source(0)
+	: name(n), output_source(0), connected_source(0),
+	thread_name({0,})
 {
 	buffer.set_enforce_keyframe(false);
 }

--- a/lib/stream_elements.h
+++ b/lib/stream_elements.h
@@ -5,6 +5,8 @@
 #include <set>
 #include <mutex>
 #include <condition_variable>
+#include <string.h>
+#include <bsd/string.h>
 
 /* These elements create a primitive chain for distributing packets from one source to
  * many consumers, and potentially for consumers to repackage those packets in a new source.
@@ -36,6 +38,7 @@ public:
 	};
 
 	const char * const name;
+	char thread_name[16];
 
 	stream_source(const char *name);
 	virtual ~stream_source();
@@ -59,6 +62,7 @@ public:
 
 	const log_context &logging_context() { return log; }
 	void set_logging_context(const log_context &context) { log = context; }
+	void set_thread_name(const char *arg) { strlcpy(thread_name, arg, sizeof(thread_name)); }
 
 protected:
 	std::set<stream_consumer*> children;
@@ -71,6 +75,7 @@ class stream_consumer
 {
 public:
 	const char * const name;
+	char thread_name[16];
 	stream_consumer(const char *name);
 	virtual ~stream_consumer();
 
@@ -88,6 +93,7 @@ public:
 
 	const log_context &logging_context() { return log; }
 	void set_logging_context(const log_context &context) { log = context; }
+	void set_thread_name(const char *arg) { strlcpy(thread_name, arg, sizeof(thread_name)); }
 
 protected:
 	/* Lock protecting buffer and buffer_wait */

--- a/server/BCMK
+++ b/server/BCMK
@@ -1,4 +1,4 @@
-CFLAGS		+= -pthread -MMD
+CFLAGS		+= -pthread -MMD $(shell pkg-config --cflags libbsd)
 LDFLAGS		+= -lbluecherry -lbsd -ludev \
 		   -lavformat -lavcodec -lavutil -lavfilter -lswscale -lavdevice -lswresample -lpugixml
 

--- a/server/bc-api.cpp
+++ b/server/bc-api.cpp
@@ -755,6 +755,7 @@ bool bc_api::start_listener(uint16_t port)
 
 void bc_api::run()
 {
+    pthread_setname_np(pthread_self(), "API");
     bool status = true;
     while (status) status = _events.service(100);
 

--- a/server/bc-server.cpp
+++ b/server/bc-server.cpp
@@ -1578,6 +1578,7 @@ int main(int argc, char **argv)
 	int hwcard_down_reported = 0;
 
 	bc_syslog_init();
+	pthread_setname_np(pthread_self(), "MAIN");
 
 	umask(007);
 

--- a/server/hls.cpp
+++ b/server/hls.cpp
@@ -1178,6 +1178,7 @@ bool hls_session::handle_request(const std::string &request)
 #ifdef BC_HLS_WITH_SSL
 static void* hls_session_thread(void *ctx)
 {
+    pthread_setname_np(pthread_self(), "HLS_SESSION");
     hls_session *session = (hls_session*)ctx;
     hls_ssl *ssl = session->get_ssl();
     uint8_t rx_buffer[HLS_REQUEST_MAX];
@@ -2047,6 +2048,8 @@ bool hls_listener::ssl_service()
 
 void hls_listener::run()
 {
+    pthread_setname_np(pthread_self(), "HLS_SERVER");
+
     if (!_init)
     {
         bc_log(Error, "HLS listener is not initialized");

--- a/server/motion_handler.cpp
+++ b/server/motion_handler.cpp
@@ -69,6 +69,7 @@ void motion_handler::set_motion_analysis_percentage(int percentage)
 
 void motion_handler::run()
 {
+	pthread_setname_np(pthread_self(), thread_name);
 	std::unique_lock<std::mutex> l(raw_stream->lock);
 	bool recording = false;
 	time_t last_motion = 0;

--- a/server/motion_processor.cpp
+++ b/server/motion_processor.cpp
@@ -95,6 +95,7 @@ void motion_processor::thread_cleanup(void *data)
 
 void motion_processor::run()
 {
+	pthread_setname_np(pthread_self(), thread_name);
 	std::shared_ptr<const stream_properties> saved_properties;
 
 	bc_log_context_push(log);

--- a/server/recorder.cpp
+++ b/server/recorder.cpp
@@ -30,6 +30,7 @@ void recorder::destroy()
 
 void recorder::run()
 {
+	pthread_setname_np(pthread_self(), thread_name);
 	std::shared_ptr<const stream_properties> saved_properties;
 	bool bool_ret;
 

--- a/server/rtsp.cpp
+++ b/server/rtsp.cpp
@@ -180,6 +180,7 @@ void rtsp_server::run()
 
 void *rtsp_server::runThread(void *p)
 {
+	pthread_setname_np(pthread_self(), "RTSP_SERVER");
 	static_cast<rtsp_server*>(p)->run();
 	return NULL;
 }

--- a/server/status_server.cpp
+++ b/server/status_server.cpp
@@ -80,6 +80,7 @@ bool status_server::socketWaitReadable(int fd, int timeout_ms) {
 }
 
 static void *servingLoopWrapper(void *arg) {
+	pthread_setname_np(pthread_self(), "STATUS");
 	status_server *self = reinterpret_cast<status_server*>(arg);
 	self->servingLoop();
 	return NULL;

--- a/server/substream-thread.cpp
+++ b/server/substream-thread.cpp
@@ -3,6 +3,7 @@
 #include "bc-server.h"
 #include "lavf_device.h"
 #include <thread>
+#include <bsd/string.h>
 
 substream::substream()
 	: /*rec(0),*/ exit_flag(false)
@@ -93,4 +94,8 @@ void substream::run(struct bc_record *r)
 void substream::stop()
 {
 	exit_flag = true;
+}
+
+void substream::set_thread_name(const char *arg) {
+	strlcpy(thread_name, arg, sizeof(thread_name));
 }

--- a/server/substream-thread.h
+++ b/server/substream-thread.h
@@ -19,6 +19,8 @@
 class substream
 {
 public:
+	char thread_name[16];
+	void set_thread_name(const char *arg);
 	explicit substream();
 	void run(struct bc_record *r);
 	void stop();

--- a/server/trigger_server.cpp
+++ b/server/trigger_server.cpp
@@ -87,6 +87,7 @@ bool trigger_server::socketWaitReadable(int fd, int timeout_ms) {
 }
 
 static void *servingLoopWrapper(void *arg) {
+	pthread_setname_np(pthread_self(), "TRIGGER");
 	trigger_server *self = reinterpret_cast<trigger_server*>(arg);
 	self->servingLoop();
 	return NULL;

--- a/server/v3license_server.cpp
+++ b/server/v3license_server.cpp
@@ -147,6 +147,7 @@ size_t v3license_server::splitArgument(const std::string &txt, std::vector<std::
 
 void* socketThread(void *arg)
 {
+    pthread_setname_np(pthread_self(), "LICENSE_SOCKET");
     license_thread_context_t* context = (license_thread_context_t*)arg;
     pthread_mutex_t* lock = &context->lock;
     int newSocket = context->socket;
@@ -279,6 +280,7 @@ void* socketThread(void *arg)
 
 void* v3license_server::runThread(void* p)
 {
+    pthread_setname_np(pthread_self(), "LICENSE");
     int server = static_cast<v3license_server*>(p)->serverfd;
 
     if (server < 0) {


### PR DESCRIPTION
With this change, we can see the purpose of each threads in the debugger, like that:

```
(gdb) info threads
  Id   Target Id                                      Frame
* 1    Thread 0x7f8ad6aef600 (LWP 3697) "MAIN"        0x00007f8ae02a5adf in __GI___clock_nanosleep (clock_id=clock_id@entry=0, flags=flags@entry=0, req=req@entry=0x7ffebcd3d9d0, rem=rem@entry=0x7ffebcd3d9d0)
    at ../sysdeps/unix/sysv/linux/clock_nanosleep.c:78
  2    Thread 0x7f8acc8da6c0 (LWP 3737) "rcn2"        0x00007f8ae0251d71 in __futex_abstimed_wait_common64 (private=32650, cancel=true, abstime=0x0, op=393, expected=0, futex_word=0x7f8ac0057680)
    at ./nptl/futex-internal.c:57
  3    Thread 0x7f8acdffb6c0 (LWP 3730) "dev2"        0x00007f8ae02d44cd in __GI___poll (fds=fds@entry=0x7f8acdfeeda0, nfds=nfds@entry=1, timeout=timeout@entry=100) at ../sysdeps/unix/sysv/linux/poll.c:29
  4    Thread 0x7f8ace7fc6c0 (LWP 3729) "dev1"        0x00007f8ae02a5adf in __GI___clock_nanosleep (clock_id=clock_id@entry=0, flags=flags@entry=0, req=req@entry=0x7f8ace7fad50, rem=rem@entry=0x7f8ace7fad50)
    at ../sysdeps/unix/sysv/linux/clock_nanosleep.c:78
  5    Thread 0x7f8aceffd6c0 (LWP 3711) "LICENSE"     0x00007f8ae02a5adf in __GI___clock_nanosleep (clock_id=clock_id@entry=0, flags=flags@entry=0, req=req@entry=0x7f8aceffbf90, rem=rem@entry=0x7f8aceffbf90)
    at ../sysdeps/unix/sysv/linux/clock_nanosleep.c:78
  6    Thread 0x7f8acf7fe6c0 (LWP 3710) "RTSP_SERVER" 0x00007f8ae02d44cd in __GI___poll (fds=0x563a41ddfda8, nfds=2, timeout=100) at ../sysdeps/unix/sysv/linux/poll.c:29
  7    Thread 0x7f8ad48246c0 (LWP 3705) "HLS_SERVER"  0x00007f8ae02e3042 in epoll_wait (epfd=13, events=0x7f8ad4825010, maxevents=120000, timeout=100) at ../sysdeps/unix/sysv/linux/epoll_wait.c:30
  8    Thread 0x7f8ad51856c0 (LWP 3704) "API"         0x00007f8ae02e3042 in epoll_wait (epfd=7, events=0x7f8ad5186010, maxevents=120000, timeout=100) at ../sysdeps/unix/sysv/linux/epoll_wait.c:30
  9    Thread 0x7f8ad5ae66c0 (LWP 3703) "MONITORING"  0x00007f8ae02a5adf in __GI___clock_nanosleep (clock_id=clock_id@entry=0, flags=flags@entry=0, req=req@entry=0x7f8ad5ae4fa0, rem=rem@entry=0x7f8ad5ae4fa0)
    at ../sysdeps/unix/sysv/linux/clock_nanosleep.c:78
  10   Thread 0x7f8ad62e76c0 (LWP 3702) "TRIGGER"     0x00007f8ae02d44cd in __GI___poll (fds=fds@entry=0x7f8ad62e5f48, nfds=nfds@entry=1, timeout=timeout@entry=100) at ../sysdeps/unix/sysv/linux/poll.c:29
  11   Thread 0x7f8ad6ae86c0 (LWP 3701) "STATUS"      0x00007f8ae02d44cd in __GI___poll (fds=fds@entry=0x7f8ad6ae6f48, nfds=nfds@entry=1, timeout=timeout@entry=100) at ../sysdeps/unix/sysv/linux/poll.c:29
```