### PR TITLE
Fix hangs of RTSP connections to cameras

### DIFF
--- a/lib/lavf_device.cpp
+++ b/lib/lavf_device.cpp
@@ -83,7 +83,7 @@ int lavf_device::start()
 
 	av_dict_set(&avopt_open_input, "allowed_media_types", audio_enabled() ? "-data" : "-audio-data", 0);
 	/* No input on socket, or no writability for thus many microseconds is treated as failure */
-	av_dict_set(&avopt_open_input, "stimeout", "10000000" /* 10 s */, 0);
+	av_dict_set(&avopt_open_input, "timeout", "10000000" /* 10 s */, 0);
 
 	if (!strncmp(url, "rtsp://", 7))
 	{


### PR DESCRIPTION
In 3.1.2 release of Bluecherry server, we have upgraded bundled FFmpeg from 4.2.1 to 6.1.1. (Later, in 3.1.3, we upgraded to FFmpeg 6.1.2.)

Between 4.2.1 and 6.1.1, FFmpeg's RTSP demuxer has changed a parameter name from "stimeout" to "timeout", but we haven't updated lib/lavf_device.cpp accordingly. This causes the cameras on which RTSP connection broke to stop working until Bluecherry server is restarted or the camera is reconfigured in the database. We have received many such complaints from the users.

Link: https://github.com/bluecherrydvr/bluecherry-apps/issues/723