### PR TITLE
Add support for oldest_recording

### DIFF
--- a/www/ajax/devices.php
+++ b/www/ajax/devices.php
@@ -106,89 +106,113 @@ class devices extends Controller {
 		$this->info['total_devices'] += count($this->ipCameras->ok);
 		$this->info['total_devices'] += count($this->ipCameras->disabled);
 	}
-	public function MakeXML(){
-		$this_user = new user('id', $_SESSION['id']);
-		// The \063 is a '?'. Used decimal so as not to confuse vim
-		$xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" \x3f>\n<devices>\n";
-		$devices = array();
-		if (!empty($this->cards)) {
-			foreach($this->cards as $card_id => $card) {
-				$devices = array_merge($devices, $card->cameras);
-			}
-		}
-		if (!empty($this->ipCameras->arr))
-			$devices = array_merge($devices, $this->ipCameras->arr);
-
-		$short_props = array('protocol', 'device_name', 'resolutionX', 'resolutionY');
-		$block_props = array('rtsp_password', 'rtsp_username');
-
-		foreach($devices as $device) {
-			if (isset($device->info['id']) and
-			    !$this_user->camPermission($device->info['id']))
-				continue;
-
-			$xml .= '  <device';
-			if (!empty($device->info['id']))
-				$xml .= ' id="' . $device->info['id'].'"';
-			$xml .= ">\n";
-
-			foreach ($device->info as $prop => $val) {
-				if (isset($_GET['short']) and
-				    !in_array($prop, $short_props))
-					continue;
-
-				if (in_array($prop, $block_props) || is_array($prop) || is_array($val))
-					continue;
-				$xml .= "    <$prop>".htmlspecialchars($val)."</$prop>\n";
-			}
-			$xml .= "  </device>\n";
-		}
-		$xml .= "</devices>";
-		header('Content-type: text/xml');
-		print $xml;
-	}
-    public function MakeJSON() {
-        $this_user = new user('id', $_SESSION['id']);
-        $devices = array();
-        if (!empty($this->cards)) {
-            foreach ($this->cards as $card_id => $card) {
-                $devices = array_merge($devices, $card->cameras);
-            }
+public function MakeXML() {
+    $this_user = new user('id', $_SESSION['id']);
+    $xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" \x3f>\n<devices>\n";
+    $devices = array();
+    if (!empty($this->cards)) {
+        foreach($this->cards as $card_id => $card) {
+            $devices = array_merge($devices, $card->cameras);
         }
-        if (!empty($this->ipCameras->arr))
-            $devices = array_merge($devices, $this->ipCameras->arr);
+    }
+    if (!empty($this->ipCameras->arr))
+        $devices = array_merge($devices, $this->ipCameras->arr);
 
-        $json_data = array('devices' => array());
+    $short_props = array('protocol', 'device_name', 'resolutionX', 'resolutionY');
+    $block_props = array('rtsp_password', 'rtsp_username');
 
-        $short_props = array('protocol', 'device_name', 'resolutionX', 'resolutionY');
-        $block_props = array('rtsp_password', 'rtsp_username');
+    foreach($devices as $device) {
+        if (isset($device->info['id']) and 
+            !$this_user->camPermission($device->info['id']))
+            continue;
 
-        foreach ($devices as $device) {
-            if (isset($device->info['id']) && !$this_user->camPermission($device->info['id']))
+        $xml .= '  <device';
+        if (!empty($device->info['id']))
+            $xml .= ' id="' . $device->info['id'].'"';
+        $xml .= ">\n";
+
+        foreach ($device->info as $prop => $val) {
+            if (isset($_GET['short']) and
+                !in_array($prop, $short_props))
                 continue;
 
-            $device_data = array();
-            if (!empty($device->info['id']))
-                $device_data['id'] = $device->info['id'];
-
-            foreach ($device->info as $prop => $val) {
-                if (isset($_GET['short']) && !in_array($prop, $short_props))
-                    continue;
-
-                if (in_array($prop, $block_props) || is_array($prop) || is_array($val))
-                    continue;
-
-                $device_data[$prop] = $val;
-            }
-
-            $json_data['devices'][] = $device_data;
+            if (in_array($prop, $block_props) || is_array($prop) || is_array($val))
+                continue;
+            $xml .= "    <$prop>".htmlspecialchars($val)."</$prop>\n";
         }
 
-        header('Content-type: application/json');
-        echo json_encode($json_data, JSON_PRETTY_PRINT);
+        // Add oldest recording date
+        if (!empty($device->info['id'])) {
+            $result = data::query("SELECT MIN(start) as oldest 
+                                 FROM Media 
+                                 WHERE device_id = {$device->info['id']}");
+            
+            if ($result[0]['oldest'] === NULL) {
+                $xml .= "    <oldest_recording>NULL</oldest_recording>\n";
+            } else {
+                $date = new DateTime('@' . $result[0]['oldest']);
+                $xml .= "    <oldest_recording>" . $date->format('c') . "</oldest_recording>\n";
+            }
+        }
+
+        $xml .= "  </device>\n";
+    }
+    $xml .= "</devices>";
+    header('Content-type: text/xml');
+    print $xml;
+}
+public function MakeJSON() {
+    $this_user = new user('id', $_SESSION['id']);
+    $devices = array();
+    if (!empty($this->cards)) {
+        foreach ($this->cards as $card_id => $card) {
+            $devices = array_merge($devices, $card->cameras);
+        }
+    }
+    if (!empty($this->ipCameras->arr))
+        $devices = array_merge($devices, $this->ipCameras->arr);
+
+    $json_data = array('devices' => array());
+
+    $short_props = array('protocol', 'device_name', 'resolutionX', 'resolutionY');
+    $block_props = array('rtsp_password', 'rtsp_username');
+
+    foreach ($devices as $device) {
+        if (isset($device->info['id']) && !$this_user->camPermission($device->info['id']))
+            continue;
+
+        $device_data = array();
+        if (!empty($device->info['id']))
+            $device_data['id'] = $device->info['id'];
+
+        foreach ($device->info as $prop => $val) {
+            if (isset($_GET['short']) && !in_array($prop, $short_props))
+                continue;
+
+            if (in_array($prop, $block_props) || is_array($prop) || is_array($val))
+                continue;
+
+            $device_data[$prop] = $val;
+        }
+
+        // Add oldest recording date
+        if (!empty($device->info['id'])) {
+            $result = data::query("SELECT MIN(start) as oldest 
+                                 FROM Media 
+                                 WHERE device_id = {$device->info['id']}");
+            
+            if ($result[0]['oldest'] === NULL) {
+                $device_data['oldest_recording'] = "NULL";
+            } else {
+                $date = new DateTime('@' . $result[0]['oldest']);
+                $device_data['oldest_recording'] = $date->format('c');
+            }
+        }
+
+        $json_data['devices'][] = $device_data;
     }
 
-
+    header('Content-type: application/json');
+    echo json_encode($json_data, JSON_PRETTY_PRINT);
+    }
 }
-
-


### PR DESCRIPTION
Should resolve this - https://github.com/bluecherrydvr/unity/issues/258

Add oldest_recording to XML and JSON, if NULL is returned add that to the tag

     {
            "id": "18",
            "device_name": "DVD Player",
            "protocol": "IP-RTSP",
            "resolutionX": "640",
            "resolutionY": "480",
            "oldest_recording": "2025-03-14T16:29:08+00:00"
        }
<device id="18">
<device_name>DVD Player</device_name>
<protocol>IP-RTSP</protocol>
<resolutionX>640</resolutionX>
<resolutionY>480</resolutionY>
<oldest_recording>2025-03-14T16:29:08+00:00</oldest_recording> </device>